### PR TITLE
fix: use node modules in build and deploy action

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -73,6 +73,20 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v2
+      - name: Cache Node modules
+        uses: actions/cache@v2
+        with:
+          path: |
+            node_modules
+          key: ${{ runner.os }}-build-${{ github.sha }}-npm-${{ hashFiles('**/package-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-build-${{ github.sha }}-npm-
+      - name: Set up Node.js
+        uses: actions/setup-node@v2
+        with:
+          node-version: '20.12'
+      - name: Install dependencies
+        run: npm install
       - name: Install Netlify CLI
         run: npm install -g netlify-cli
       - name: Build project


### PR DESCRIPTION
# Issue Link

- #11 

## Feature

- 修正 `build_and_deploy` 因為沒有找到 node_modules 而失敗的問題